### PR TITLE
fix: avoid hardcode executable path

### DIFF
--- a/src/src/aria2/aria2rpcinterface.cpp
+++ b/src/src/aria2/aria2rpcinterface.cpp
@@ -87,9 +87,9 @@ bool Aria2RPCInterface::startUp()
     QString saveSessionInterval = "30"; //秒
 
     qDebug() << "创建session缓存文件: " << sessionCacheFile;
-    QProcess::execute("/usr/bin/touch", QStringList() << sessionCacheFile); //创建session缓存文件
-    //QProcess::execute("/usr/bin/touch", QStringList() << dhtFile); //创建dht文件
-    //QProcess::execute("/usr/bin/touch", QStringList() << dht6File); //创建dht6文件
+    QProcess::execute("touch", QStringList() << sessionCacheFile); //创建session缓存文件
+    //QProcess::execute("touch", QStringList() << dhtFile); //创建dht文件
+    //QProcess::execute("touch", QStringList() << dht6File); //创建dht6文件
 
     QString opt;
     opt += " --enable-rpc=true"; //启动RPC


### PR DESCRIPTION
`QProcess::execute()` 本身会尝试在 PATH 中查找要执行的程序，故尝试执行 PATH 中的程序时，应当避免硬编码可执行程序的路径以提高可移植性。

相关：https://github.com/linuxdeepin/developer-center/issues/3374