### PR TITLE
chore: start dlm service by dbus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,14 @@ LIBRARY DESTINATION lib
 ARCHIVE DESTINATION libstatic
 )
 
+if (USE_AM_DBUS)
+set(SERVICE_SCRIPT docs/dbus/startdlmservice.sh)
+else()
+set(SERVICE_SCRIPT docs/nodbus/startdlmservice.sh)
+endif()
+
 install(DIRECTORY ${APP_RES_DIR}/downloader DESTINATION /usr/share/deepin-manual/manual-assets/application/)
 install(FILES docs/info.json DESTINATION share/downloader/extension/)
 install(FILES docs/ojlicckikdkkaclkpdddijgehekpmmbg.crx DESTINATION share/downloader/extension/)
 install(FILES docs/browser.downloader.autostart.json DESTINATION /etc/browser/native-messaging-hosts/)
-install(FILES docs/startdlmservice.sh DESTINATION /usr/libexec/openconnect/)
-
-
-
-
+install(FILES ${SERVICE_SCRIPT} DESTINATION /usr/libexec/openconnect/)

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,8 @@ Homepage: https://www.deepin.org/
 
 Package: org.deepin.downloader
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libdlmaria2, libdlmcontrolui, libdlmdatabase, libdlmlog
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdlmaria2, 
+ libdlmcontrolui, libdlmdatabase, libdlmlog, libglib2.0-bin, dde-applicaiton-manager
 Description: it's a user-friendly download manager, supporting URLs and torrent files.
  downloader for deepin desktop environment.
 

--- a/debian/org.deepin.downloader.install
+++ b/debian/org.deepin.downloader.install
@@ -12,6 +12,6 @@ docs/content-type.conf /usr/share/downloader/config
 docs/httpAdvanced.json /usr/share/downloader/config
 docs/content-type.conf /usr/share/downloader/config
 docs/browser.downloader.autostart.json /etc/browser/native-messaging-hosts
-docs/startdlmservice.sh /usr/libexec/openconnect/
+/usr/libexec/openconnect/startdlmservice.sh
 docs/ojlicckikdkkaclkpdddijgehekpmmbg.crx /usr/share/downloader/extension
 docs/info.json /usr/share/downloader/extension

--- a/debian/rules
+++ b/debian/rules
@@ -7,3 +7,10 @@ export QT_SELECT=qt5
 
 override_dh_auto_test:
 	# Disable auto tests at build time
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	  -DUSE_AM_DBUS=ON \
+	  -DCMAKE_BUILD_TYPE=Release \
+	  -DCMAKE_INSTALL_PREFIX=/usr \
+      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib

--- a/docs/dbus/startdlmservice.sh
+++ b/docs/dbus/startdlmservice.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gdbus call --session  --dest com.deepin.SessionManager --object-path /com/deepin/StartManager --method com.deepin.StartManager.RunCommand "dlmextensionservice" "['&']"

--- a/docs/nodbus/startdlmservice.sh
+++ b/docs/nodbus/startdlmservice.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+nohup dlmextensionservice &

--- a/docs/startdlmservice.sh
+++ b/docs/startdlmservice.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-nohup /usr/bin/dlmextensionservice &

--- a/src/src/ui/CMakeLists.txt
+++ b/src/src/ui/CMakeLists.txt
@@ -125,8 +125,19 @@ add_library(dlmcontrolui SHARED
        ${QM_FILES}
 )
 
-target_link_libraries(dlmcontrolui dlmlog dlmaria2 dlmdatabase dtkcore  dtkwidget
-    Qt5::Core Qt5::Network Qt5::Widgets Qt5::Svg Qt5::DBus)
+target_link_libraries(dlmcontrolui 
+    dlmlog
+    dlmaria2
+    dlmdatabase
+    Dtk::Core
+    Dtk::Widget
+    Dtk::Gui
+    Qt5::Core
+    Qt5::Network
+    Qt5::Widgets
+    Qt5::Svg
+    Qt5::DBus
+)
 
 #install(TARGETS dlmcontrolui DESTINATION lib)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,7 +86,7 @@ add_executable(${PROJECT_NAME_TEST} ${SRC_LIST} ${ALL_HEADERS} ${ALL_SOURCES} ${
 
 #添加gtest库，Qt库，dtk库
 target_link_libraries(${PROJECT_NAME_TEST} gmock gmock_main gtest gtest_main pthread
-    Qt5::Core Qt5::Network Qt5::Widgets Qt5::Svg Qt5::DBus Qt5::Sql Qt5::Test dtkwidget dtkgui dtkcore Qt5::WebChannel Qt5::WebSockets)
+    Qt5::Core Qt5::Network Qt5::Widgets Qt5::Svg Qt5::DBus Qt5::Sql Qt5::Test Dtk::Widget Dtk::Gui Dtk::Core Qt5::WebChannel Qt5::WebSockets)
 
 # 添加 QTest 测试
 add_test(${PROJECT_NAME_TEST} COMMAND ${PROJECT_NAME_TEST})


### PR DESCRIPTION
1. 修复构建失败问题
2. 临时通过dde-application-manager 的dbus接口启动 dlmservice
close #developer-center/issues/3648