### PR TITLE
chore: remove libdframeworkdbus-dev build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Build-Depends:
  qt6-websockets-dev,
  libdtk6widget-dev,
  libdtk6gui-dev,
- libdframeworkdbus-dev,
  libgtest-dev,
  libgmock-dev,
  sqlite3,


### PR DESCRIPTION
Remove unnecessary build dependency libdframeworkdbus-dev from debian/control

Log: remove libdframeworkdbus-dev build dependency

## Summary by Sourcery

Chores:
- Removes the libdframeworkdbus-dev build dependency.