### PR TITLE
chore: Bump version to 6.0.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-downloader (6.0.4) unstable; urgency=medium
+
+  * chore: New version 6.0.4.
+
+ -- Wang Yu <wangyu@uniontch.com>  Thu, 27 Mar 2025 13:50:47 +0800
+
 deepin-downloader (6.0.3) unstable; urgency=medium
 
   * fix: update translations and config.


### PR DESCRIPTION
Bump version to 6.0.4

Log: Bump version to 6.0.4

## Summary by Sourcery

Chores:
- Increment project version number to 6.0.4