### PR TITLE
fix: Icon fail to display correctly in the help manual

### DIFF
--- a/assets/downloader/downloader/en_US/downloader.md
+++ b/assets/downloader/downloader/en_US/downloader.md
@@ -1,4 +1,4 @@
-# Downloader | downloader
+# Downloader|downloader|
 
 ## Overview
 

--- a/assets/downloader/downloader/zh_HK/downloader.md
+++ b/assets/downloader/downloader/zh_HK/downloader.md
@@ -1,4 +1,4 @@
-# 下載器 | downloader
+# 下載器|downloader|
 
 ## 概述
 

--- a/assets/downloader/downloader/zh_TW/downloader.md
+++ b/assets/downloader/downloader/zh_TW/downloader.md
@@ -1,4 +1,4 @@
-# 下載器 | downloader
+# 下載器|downloader|
 
 ## 概述
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-downloader (6.0.8) unstable; urgency=medium
+
+  * fix bug
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Tue, 24 Jun 2025 17:31:42 +0800
+
 deepin-downloader (6.0.7) unstable; urgency=medium
 
   * update translations.


### PR DESCRIPTION
as title

Log: fix bug

## Summary by Sourcery

Fix formatting issues in the Downloader help manual to ensure correct icon rendering

Documentation:
- Correct the main header spacing and pipe syntax in the downloader manual
- Remove the inaccurate "Exit" instruction at the end of the help guide