### PR TITLE
BUG: fix(diagnostic): 修复诊断工具误报与“再次诊断”无响应

### DIFF
--- a/src/src/ui/settings/diagnostictool.cpp
+++ b/src/src/ui/settings/diagnostictool.cpp
@@ -246,14 +246,19 @@ void DiagnosticModel::appendData(bool b)
 {
     qDebug() << "Appending diagnostic data, status:" << b;
     const int row = m_DiagnosticStatusList.size();
-    beginInsertRows(QModelIndex(), row, row);
-    m_DiagnosticStatusList.append(b);
-    endInsertRows();
+    if (row < 6) {
+        m_DiagnosticStatusList.append(b);
+        // 不再用插入行（因为行数固定为6），改为按行触发 dataChanged，
+        // 并在清空时使用 reset 通知，这样结果会自动刷新而无需点击界面
+        emit dataChanged(index(row, 0), index(row, 2));
+    }
 }
 
 void DiagnosticModel::clearData()
 {
+    beginResetModel();
     m_DiagnosticStatusList.clear();
+    endResetModel();
 }
 
 bool DiagnosticModel::setData(const QModelIndex &index, const QVariant &value, int role)


### PR DESCRIPTION
问题
- 下载成功但诊断工具仍提示“DTS 下载失败”
- DHT 状态偶发误判
- 诊断结果需鼠标点一下窗口才刷新

原因
- aria2 返回的 enable-dht 可能为字符串/布尔，原判定不够稳健
- 诊断模型行数固定为 6，却按“插入行”方式更新，未正确触发视图刷新

最小改动与解决
- src/src/ui/mainFrame/mainframe.cpp
  - DHT 判定使用 obj.value("enable-dht").toVariant().toBool()，兼容不同类型，避免误判
  - 打开诊断窗口前调用 Aria2RPCInterface::getGlobalOption() 预热，消除时序导致的误判（不改诊断工具逻辑）
- src/src/ui/settings/diagnostictool.cpp
  - appendData：不再插入行，改为在内部列表追加后对该行三列 emit dataChanged，保证视图立即刷新
  - clearData：使用 beginResetModel/endResetModel，确保清空时完整重置

验证
- 成功下载后打开“诊断工具”，DHT/HTTP/BT/磁链在网络可用时显示“正常”
- 点击“再次诊断”，列表结果自动更新，无需与窗口交互