### PR TITLE
chore: Update version to 6.0.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-downloader (6.0.16) unstable; urgency=medium
+
+  * fix(diagnostic): Stabilize DHT determination and ensure automatic refresh of diagnostic results
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 18 Sep 2025 19:32:48 +0800
+
 deepin-downloader (6.0.15) unstable; urgency=medium
 
   *Update version to 6.0.15. 


### PR DESCRIPTION
- update version to 6.0.16

 log: update version to 6.0.16

## Summary by Sourcery

Chores:
- Update Debian changelog to version 6.0.16