### PR TITLE
chore: Update version to 6.0.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-downloader (6.0.19) unstable; urgency=medium
+
+  * fix: Enhance error handling in Aria2RPC and DBInstance
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 06 Mar 2026 09:07:55 +0800
+
 deepin-downloader (6.0.18) unstable; urgency=medium
 
   * fix: Improve command execution for file operations


### PR DESCRIPTION
- update version to 6.0.19

log: update version to 6.0.19

## Summary by Sourcery

Chores:
- Update Debian packaging metadata to reference version 6.0.19.