### PR TITLE
fix(ui): set left list view background type to NoBackground

### DIFF
--- a/src/src/ui/mainFrame/mainframe.cpp
+++ b/src/src/ui/mainFrame/mainframe.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -229,6 +229,7 @@ void MainFrame::init()
 
     m_LeftList = new LeftListView;
     m_LeftList->setObjectName("leftList");
+    m_LeftList->setBackgroundType(DStyledItemDelegate::NoBackground);
     m_LeftList->setItemSpacing(0);
     m_LeftList->setItemSize(QSize(112, 40));
     m_LeftList->setItemMargins(QMargins(10, 2, 5, 2));


### PR DESCRIPTION
Set DStyledItemDelegate::NoBackground for left list view to fix unexpected background rendering issue.

设置左侧列表视图的背景类型为 NoBackground，修复背景渲染异常。

Log: 修复左侧列表背景显示异常
PMS: BUG-310579
Influence: 修复左侧导航列表的背景显示问题，使界面显示更加正常。

## Summary by Sourcery

Fix background rendering of the left navigation list view.

Bug Fixes:
- Set the left list view background type to NoBackground to resolve incorrect background rendering.

Enhancements:
- Update mainframe source file copyright years to cover 2022–2026.