### PR TITLE
fix(ui): set left list view background type adapt to hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 .vscode/
 .cache/
 build*/
+obj-x86_64-linux-gnu/
 
 # AI config
 .promptx/

--- a/src/src/ui/mainFrame/mainframe.cpp
+++ b/src/src/ui/mainFrame/mainframe.cpp
@@ -229,7 +229,8 @@ void MainFrame::init()
 
     m_LeftList = new LeftListView;
     m_LeftList->setObjectName("leftList");
-    m_LeftList->setBackgroundType(DStyledItemDelegate::NoBackground);
+    m_LeftList->setBackgroundType(static_cast<DStyledItemDelegate::BackgroundType>(
+        DStyledItemDelegate::RoundedBackground | DStyledItemDelegate::NoNormalState));
     m_LeftList->setItemSpacing(0);
     m_LeftList->setItemSize(QSize(112, 40));
     m_LeftList->setItemMargins(QMargins(10, 2, 5, 2));


### PR DESCRIPTION
Set DStyledItemDelegate::NoBackground for left list view to fix unexpected background rendering issue.
设置左侧列表视图的背景类型为 NoBackground | NoNormalState，
保证鼠标hover效果，修复背景渲染异常。

Log: 修复左侧列表背景显示异常
PMS: BUG-310579
Influence: 修复左侧导航列表的背景显示问题，使界面显示更加正常。

## Summary by Sourcery

Bug Fixes:
- Fix incorrect background rendering of the left navigation list by updating its styled item delegate background type.