### PR TITLE
fix(ui): use system theme icon for better integration

### DIFF
--- a/src/include/ui/mainFrame/topButton.h
+++ b/src/include/ui/mainFrame/topButton.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -175,7 +175,6 @@ signals:
     void SearchEditKeyPressed(Qt::Key);
 
 private:
-    Dtk::Widget::DLabel *m_iconLable;
     Dtk::Widget::DIconButton *m_newDownloadBtn;
     Dtk::Widget::DIconButton *m_startDownloadBtn;
     Dtk::Widget::DIconButton *m_stopDownloadBtn;

--- a/src/src/downloader/main.cpp
+++ b/src/src/downloader/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     a.setApplicationName(QObject::tr("downloader")); //设置应用程序名
     a.setApplicationDisplayName(QObject::tr("Downloader"));
     a.setApplicationVersion(DLM_VERSION_STRING); //设置应用程序版本
-    a.setProductIcon(QIcon(":/icons/icon/downloader.svg")); //从系统主题中获取图标并设置成产品图标
+    a.setProductIcon(QIcon::fromTheme("downloader", QIcon(":/icons/icon/downloader.svg")));
     a.setProductName(QObject::tr("Downloader")); //设置产品的名称
     a.setApplicationDescription(QObject::tr("Downloader is a user-friendly download tool, supporting URLs and torrent files")); //设置产品的描述信息
     //a.setApplicationDisplayName(QCoreApplication::translate("Main", "Uos Download Management Application")); //设置应用程序的显示信息
@@ -201,7 +201,6 @@ int main(int argc, char *argv[])
             w.OpenFile(comList[i]);
         }
     }
-    w.setWindowIcon(QIcon(":/icons/icon/downloader.svg"));
     QObject::connect(&a, &DlmApplication::applicatinQuit, &w, &MainFrame::onTrayQuitClick);
 
     return a.exec();

--- a/src/src/ui/mainFrame/mainframe.cpp
+++ b/src/src/ui/mainFrame/mainframe.cpp
@@ -140,6 +140,7 @@ void MainFrame::init()
     pSettingsMenu->addAction(pDiagnosticAction);
 
     titlebar()->setMenu(pSettingsMenu);
+    titlebar()->setIcon(QIcon::fromTheme("downloader", QIcon(":/icons/icon/downloader.svg")));
     m_ToolBar = new TopButton(this);
     titlebar()->setCustomWidget(m_ToolBar, false);
     titlebar()->setObjectName("titlebar");

--- a/src/src/ui/mainFrame/topButton.cpp
+++ b/src/src/ui/mainFrame/topButton.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -64,24 +64,7 @@ void TopButton::Init()
 
     mainHlayout->setContentsMargins(0, 5, 0, 5);
     mainHlayout->setSpacing(10);
-    m_iconLable = new DLabel;
-    QIcon logo_icon = QIcon(":icons/icon/downloader5.svg");
-#ifdef DTKWIDGET_CLASS_DSizeMode
-    if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::NormalMode) {
-        m_iconLable->setPixmap(logo_icon.pixmap(32, 32));
-    } else {
-        m_iconLable->setPixmap(logo_icon.pixmap(32*Global::compactMode_ratio, 32*Global::compactMode_ratio));
-    }
-    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [=](DGuiApplicationHelper::SizeMode sizeMode) {
-        if (sizeMode == DGuiApplicationHelper::NormalMode) {
-            m_iconLable->setPixmap(logo_icon.pixmap(32, 32));
-        } else {
-            m_iconLable->setPixmap(logo_icon.pixmap(32*Global::compactMode_ratio, 32*Global::compactMode_ratio));
-        }
-    });
-#else
-    m_iconLable->setPixmap(logo_icon.pixmap(32, 32));
-#endif
+
     m_searchEdit = new SearchWidget();
     m_searchEdit->setMinimumWidth(380);
     m_searchEdit->lineEdit()->setMaxLength(256);
@@ -115,8 +98,6 @@ void TopButton::Init()
     m_deleteDownloadBtn->setToolTip(tr("Delete"));
 
     mainHlayout->addSpacing(10);
-    mainHlayout->addWidget(m_iconLable);
-    mainHlayout->addSpacing(7);
     mainHlayout->addWidget(m_pauseDownloadBtn);
     mainHlayout->addWidget(m_startDownloadBtn);
 


### PR DESCRIPTION
Replace hardcoded icon paths with QIcon::fromTheme to use system theme icons, providing better visual integration with the desktop environment.

使用系统主题图标替代硬编码路径，提供更好的桌面环境视觉集成。

Log: 使用系统主题图标
PMS: BUG-280491
Influence: 应用图标现在优先使用系统主题，提升与桌面环境的集成度和视觉一致性。