### PR TITLE
fix(ui): adjust editor position to avoid covering file icon

### DIFF
--- a/src/src/ui/mainFrame/itemDelegate.cpp
+++ b/src/src/ui/mainFrame/itemDelegate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -440,6 +440,10 @@ QWidget *ItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem 
         }
     });
     pEdit->resize(parent->size());
+    // Only column 1 has file icon, so adjust editor position to not cover it
+    if (index.column() == 1) {
+        pEdit->setContentsMargins(20, 0, 0, 0);
+    }
     // qDebug() << "[ItemDelegate] createEditor function ended with DLineEdit*";
     return pEdit;
 }


### PR DESCRIPTION
Add left margin for column 1 editor to prevent covering file icon.

为第1列编辑器添加左边距，避免覆盖文件图标。

Log: 修复编辑器覆盖文件图标问题
PMS: BUG-282653
Influence: 修复后编辑文件名时不会覆盖文件图标，提升用户体验。

## Summary by Sourcery

Adjust inline editor positioning in the main frame item delegate to prevent it from overlapping the file icon when editing filenames.

Bug Fixes:
- Prevent the filename editor in column 1 from covering the file icon by adding a left margin.

Chores:
- Update the SPDX copyright notice year range for the item delegate source file.