### PR TITLE
fix(ui): remove reset call to fix edit commit issue

### DIFF
--- a/src/src/ui/mainFrame/tableView.cpp
+++ b/src/src/ui/mainFrame/tableView.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -179,7 +179,9 @@ void TableView::mousePressEvent(QMouseEvent *event)
         //setCurrentIndex(QModelIndex());
         QTableView::mousePressEvent(event);
         QModelIndex index = indexAt(event->pos());
-        this->reset();
+        // Note: Removed this->reset() call here to fix issue where clicking blank area
+        // during editing would fail to commit the rename. The reset call was interfering
+        // with Qt's normal edit commit process.
         if ((index.row() < 0) && (index.column() < 0)) {
             currentChanged(m_PreviousIndex.sibling(m_PreviousIndex.row(), 0), m_PreviousIndex);
             //return;


### PR DESCRIPTION
Removed this->reset() call in mousePressEvent to prevent interruption of Qt's normal edit commit process when clicking blank area during editing.

移除 mousePressEvent 中的 this->reset() 调用，防止在编辑过程中
点击空白区域时干扰 Qt 的正常编辑提交流程。

Log: 修复编辑提交失败问题
PMS: BUG-282659
Influence: 修复后，用户在编辑文件名时点击空白区域能够正常提交修改，避免编辑内容丢失。