### PR TITLE
fix(settings): adapt to new control center interface

### DIFF
--- a/src/include/ui/settings/notificationssettiingwidget.h
+++ b/src/include/ui/settings/notificationssettiingwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,6 +50,10 @@ public:
 signals:
 
 public slots:
+
+private:
+    void openControlCenterNotificationSettings();
+    void tryOldInterface();
 };
 
 #endif // NOTIFICATIONSSETTIINGWIDGET_H

--- a/src/src/ui/settings/notificationssettiingwidget.cpp
+++ b/src/src/ui/settings/notificationssettiingwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -35,7 +35,15 @@
 #include <qlayout.h>
 #include <QDBusConnection>
 #include <QDBusInterface>
-#include <QDBusPendingCall>
+#include <QDBusMessage>
+
+static const QString CONTROL_CENTER1_SERVICE = "org.deepin.dde.ControlCenter1";
+static const QString CONTROL_CENTER1_PATH = "/org/deepin/dde/ControlCenter1";
+static const QString CONTROL_CENTER1_INTERFACE = "org.deepin.dde.ControlCenter1";
+
+static const QString CONTROL_CENTER_SERVICE = "com.deepin.dde.ControlCenter";
+static const QString CONTROL_CENTER_PATH = "/com/deepin/dde/ControlCenter";
+static const QString CONTROL_CENTER_INTERFACE = "com.deepin.dde.ControlCenter";
 
 NotificationsSettiingWidget::NotificationsSettiingWidget(QWidget *parent)
     : QWidget(parent)
@@ -67,12 +75,39 @@ NotificationsSettiingWidget::NotificationsSettiingWidget(QWidget *parent)
     QHBoxLayout *pLayout = new QHBoxLayout(this);
     pLayout->addLayout(pVLayout);
     pLayout->addWidget(btn);
-    connect(btn, &QPushButton::clicked, this, []() {
-        qDebug() << "Opening control center notification settings";
-        QDBusInterface iface("com.deepin.dde.ControlCenter",
-                             "/com/deepin/dde/ControlCenter",
-                             "com.deepin.dde.ControlCenter",
-                             QDBusConnection::sessionBus());
-        iface.asyncCall("ShowPage", "notification", "下载器");
-    });
+    connect(btn, &QPushButton::clicked, this, &NotificationsSettiingWidget::openControlCenterNotificationSettings);
+}
+
+void NotificationsSettiingWidget::openControlCenterNotificationSettings()
+{
+    qDebug() << "Opening control center notification settings";
+
+    QDBusInterface controlCenter1Interface(CONTROL_CENTER1_SERVICE,
+                                          CONTROL_CENTER1_PATH,
+                                          CONTROL_CENTER1_INTERFACE,
+                                          QDBusConnection::sessionBus());
+
+    QDBusMessage reply = controlCenter1Interface.call("ShowPage", "notification", "list/downloader");
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qDebug() << "ShowPage with specific page failed, trying with just notification:" << reply.errorMessage();
+
+        QDBusMessage fallbackReply = controlCenter1Interface.call("ShowPage", "notification");
+        if (fallbackReply.type() == QDBusMessage::ErrorMessage) {
+            qDebug() << "New ControlCenter1 interface failed, trying old interface:" << fallbackReply.errorMessage();
+            tryOldInterface();
+        }
+    }
+}
+
+void NotificationsSettiingWidget::tryOldInterface()
+{
+    QDBusInterface oldIface(CONTROL_CENTER_SERVICE,
+                           CONTROL_CENTER_PATH,
+                           CONTROL_CENTER_INTERFACE,
+                           QDBusConnection::sessionBus());
+
+    QDBusMessage reply = oldIface.call("ShowPage", "notification", "下载器");
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "Failed to open control center with old interface:" << reply.errorMessage();
+    }
 }


### PR DESCRIPTION
Update notification settings to use new ControlCenter1 D-Bus interface with fallback to old interface for compatibility.

更新通知设置以使用新的ControlCenter1 D-Bus接口，并保留旧接口作为回退方案。

Log:适配新的控制中心接口
PMS: BUG-350431
Influence:修复后通知设置按钮能够正确打开控制中心的通知设置页面，提升用户体验。