### PR TITLE
fix: use QUrl::fromLocalFile for file URLs

### DIFF
--- a/src/src/ui/mainFrame/mainframe.cpp
+++ b/src/src/ui/mainFrame/mainframe.cpp
@@ -2571,12 +2571,10 @@ void MainFrame::onOpenFileActionTriggered()
     qDebug() << "[MainFrame] onOpenFileActionTriggered function started";
     if (m_CurrentTab == CurrentTab::finishTab) {
         qDebug() << "Current tab is finish tab";
-        QString path = QString("file:///") + m_CheckItem->savePath;
-        QDesktopServices::openUrl(QUrl(path, QUrl::TolerantMode));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(m_CheckItem->savePath));
     } else if (m_CurrentTab == recycleTab) {
         qDebug() << "Current tab is recycle tab";
-        QString path = QString("file:///") + m_DelCheckItem->savePath;
-        QDesktopServices::openUrl(QUrl(path, QUrl::TolerantMode));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(m_DelCheckItem->savePath));
     }
     qDebug() << "[MainFrame] onOpenFileActionTriggered function ended";
 }
@@ -2588,14 +2586,12 @@ void MainFrame::onOpenFolderActionTriggered()
         qDebug() << "Current tab is recycle tab";
         QString filePath = m_DelCheckItem->savePath.left(m_DelCheckItem->savePath.length()
                                                          - m_DelCheckItem->savePath.split('/').last().length());
-        QString path = QString("file:///") + filePath;
-        QDesktopServices::openUrl(QUrl(path, QUrl::TolerantMode));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(filePath));
     } else {
         qDebug() << "Current tab is downloading tab or finish tab";
         QString filePath = m_CheckItem->savePath.left(m_CheckItem->savePath.length()
                                                       - m_CheckItem->savePath.split('/').last().length());
-        QString path = QString("file:///") + filePath;
-        QDesktopServices::openUrl(QUrl(path, QUrl::TolerantMode));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(filePath));
     }
     qDebug() << "[MainFrame] onOpenFolderActionTriggered function ended";
 }

--- a/src/src/ui/mainFrame/tabledatacontrol.cpp
+++ b/src/src/ui/mainFrame/tabledatacontrol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -430,10 +430,7 @@ bool TableDataControl::aria2MethodStatusChanged(QJsonObject &json, int iCurrentR
         dealNotificaitonSettings(statusStr, fileName, errorCode);
         if (Settings::getInstance()->getDownloadFinishedOpenState() && (!isMetaData) && (!fileName.endsWith(".torrent"))) {
             qDebug() << "Settings::getInstance()->getDownloadFinishedOpenState() is true";
-            QString urlDecode = QUrl::fromPercentEncoding(filePath.toUtf8());
-            urlDecode = "file:///" + urlDecode;
-            QUrl url = QUrl(urlDecode, QUrl::TolerantMode);
-            QDesktopServices::openUrl(url);
+            QDesktopServices::openUrl(QUrl::fromLocalFile(filePath));
         }
         if (!checkTaskStatus()) {
             qDebug() << "checkTaskStatus() is false";


### PR DESCRIPTION
Replace manual file:/// URL construction with QUrl::fromLocalFile.

使用QUrl::fromLocalFile替换手动拼接的file:/// URL。

Log: 修复文件URL构造方式
PMS: BUG-362445
Influence: 修复文件打开和下载完成后自动打开文件的功能