### PR TITLE
test: migrate unit tests to Qt6 build environment

### DIFF
--- a/src/src/ui/createTask/btinfodialog.cpp
+++ b/src/src/ui/createTask/btinfodialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -721,7 +721,7 @@ QString BtInfoDialog::getFileEditText(QString text)
 {
     qDebug() << "[BtInfoDialog] getFileEditText function started with text:" << text;
     QString flieEditText = text + "    " + tr("Available:") + Aria2RPCInterface::instance()->getCapacityFree(text);
-    int count = text.count();
+    int count = text.size();
     int hasLongStr = 0;
 
     for (int i = 0; i < flieEditText.size(); i++) {

--- a/src/src/ui/settings/itemselectionwidget.cpp
+++ b/src/src/ui/settings/itemselectionwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,7 +77,7 @@ void ItemSelectionWidget::initUI(bool isHttp)
 void ItemSelectionWidget::initConnections()
 {
     qDebug() << "Initializing item selection widget connections";
-    connect(m_checkBox, &QCheckBox::stateChanged, this, &ItemSelectionWidget::onCheckBoxStateChanged);
+    connect(m_checkBox, &QCheckBox::checkStateChanged, this, &ItemSelectionWidget::onCheckBoxStateChanged);
 }
 
 void ItemSelectionWidget::onCheckBoxStateChanged(int state)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ ADD_COMPILE_OPTIONS(-fno-access-control)
 ADD_COMPILE_OPTIONS(-fno-inline)
 #添加-fno-inline编译选项，禁止内联，能获取到函数地址，可以对内联函数进行打桩
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-inline")
+#抑制 stub 框架将成员函数指针转换为 C 函数指针时的警告（-Wpmf-conversions）
+#stub.h 通过 mprotect + 内联汇编修改函数体实现打桩，运行时不受此转换影响
+ADD_COMPILE_OPTIONS(-Wno-pmf-conversions)
 
 set(CMAKE_SAFETYTEST "${CMAKE_SAFETYTEST_ARG}")
 if(CMAKE_SAFETYTEST STREQUAL "")

--- a/tests/qt_event_helper.h
+++ b/tests/qt_event_helper.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef QT_EVENT_HELPER_H
+#define QT_EVENT_HELPER_H
+
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QFocusEvent>
+#include <QDragEnterEvent>
+#include <QPoint>
+
+// Qt6.4+ 中 QMouseEvent 旧构造函数已废弃，统一使用新构造函数
+inline QMouseEvent *createMouseEvent(QEvent::Type type, const QPoint &pos,
+                                     Qt::MouseButton button, Qt::MouseButtons buttons,
+                                     Qt::KeyboardModifiers modifiers)
+{
+#if QT_VERSION_MAJOR > 5
+    // Qt6: 使用带 globalPos 参数的非废弃构造函数
+    return new QMouseEvent(type, pos, pos, button, buttons, modifiers);
+#else
+    return new QMouseEvent(type, pos, button, buttons, modifiers);
+#endif
+}
+
+#endif // QT_EVENT_HELPER_H

--- a/tests/ui/createTask/ut_createtaskwidget.cpp
+++ b/tests/ui/createTask/ut_createtaskwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 #include <QPalette>
 #include <QFileInfo>
 #include <QMimeData>
+#include "qt_event_helper.h"
 #include "taskdelegate.h"
 #include "gtest/gtest.h"
 #include "createtaskwidget.h"
@@ -248,7 +249,7 @@ TEST_F(ut_CreateTaskWidget, trueUrltableStatus)
     TaskDelegate *dlg = c->findChild<TaskDelegate *>("taskDelegate");
 
     QTest::mouseClick(view->viewport(), Qt::LeftButton, Qt::KeyboardModifiers(), rect.center());
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     view->mouseReleaseEvent(event);
     QTest::qWait(100);
     c->close();
@@ -355,7 +356,7 @@ TEST_F(ut_CreateTaskWidget, getFtpFileSize)
 TEST_F(ut_CreateTaskWidget, tableView1)
 {
     BtInfoTableView *table = new BtInfoTableView();
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->mouseMoveEvent(event);
     delete table;
     delete event;
@@ -364,7 +365,7 @@ TEST_F(ut_CreateTaskWidget, tableView1)
 TEST_F(ut_CreateTaskWidget, tableView2)
 {
     BtInfoTableView *table = new BtInfoTableView();
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->leaveEvent(event);
     delete table;
     delete event;
@@ -374,7 +375,7 @@ TEST_F(ut_CreateTaskWidget, tableView2)
 TEST_F(ut_CreateTaskWidget, tableView3)
 {
     BtInfoTableView *table = new BtInfoTableView();
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->mouseReleaseEvent(event);
     delete table;
     delete event;

--- a/tests/ui/mainFrame/ut_mainframe.cpp
+++ b/tests/ui/mainFrame/ut_mainframe.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QTimer>
 #include <QDBusMessage>
+#include "qt_event_helper.h"
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QDBusPendingCall>
@@ -904,7 +905,7 @@ TEST_F(ut_MainFreme, initTabledata)
 TEST_F(ut_MainFreme, tableView)
 {
     TableView *table = new TableView(1);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->mousePressEvent(event);
     delete table;
     delete event;
@@ -913,7 +914,7 @@ TEST_F(ut_MainFreme, tableView)
 TEST_F(ut_MainFreme, tableView2)
 {
     TableView *table = new TableView(1);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->mouseMoveEvent(event);
     delete table;
     delete event;
@@ -922,7 +923,7 @@ TEST_F(ut_MainFreme, tableView2)
 TEST_F(ut_MainFreme, tableView3)
 {
     TableView *table = new TableView(1);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *event = createMouseEvent(QEvent::MouseButtonPress, QPoint(1, 1), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     table->mouseReleaseEvent(event);
     delete table;
     delete event;

--- a/tests/ui/settings/ut_settings.cpp
+++ b/tests/ui/settings/ut_settings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -612,7 +612,13 @@ TEST_F(ut_Settings, DownloadSettingWidget3)
 TEST_F(ut_Settings, FileSavePathChooser)
 {
     FileSavePathChooser *pWidget = new FileSavePathChooser(1, "");
-    pWidget->onRadioButtonClicked();
+    // 使用 QTest::mouseClick 模拟真实按钮点击，避免直接调用 slot 时 sender() 为 nullptr 导致段错误
+    DRadioButton *customBtn = pWidget->findChild<DRadioButton *>("customPathBtn");
+    DRadioButton *lastPathBtn = pWidget->findChild<DRadioButton *>("lastPathBtn");
+    if (customBtn && lastPathBtn) {
+        QTest::mouseClick(customBtn, Qt::LeftButton);
+        QTest::mouseClick(lastPathBtn, Qt::LeftButton);
+    }
     delete pWidget;
 }
 


### PR DESCRIPTION
Adapt test code and source code for Qt6 compatibility. Fix deprecated Qt5 APIs and segfault in FileSavePathChooser test.

适配测试代码和源代码以兼容Qt6编译环境。
修复废弃的Qt5 API调用以及FileSavePathChooser测试的段错误问题。

Log: 迁移单元测试至Qt6编译环境
Influence: 单元测试现在可在Qt6环境下编译通过，零错误零警告。