### PR TITLE
chore: Update version to 6.0.22

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-downloader (6.0.22) unstable; urgency=medium
+
+  * chore: Update version to 6.0.22
+  * [skip CI] Translate downloader.ts in cs
+  * test: migrate unit tests to Qt6 build environment
+  * fix: use QUrl::fromLocalFile for file URLs
+  * [skip CI] Translate downloader.ts in ru
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 12 Jun 2026 09:01:46 +0800
+
 deepin-downloader (6.0.21) unstable; urgency=medium
 
   * chore: Update version to 6.0.21


### PR DESCRIPTION
- update version to 6.0.22

log: update version to 6.0.22

## Summary by Sourcery

Bump Debian package version metadata to 6.0.22 in the changelog.