### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/desktop/downloader.desktop
+++ b/desktop/downloader.desktop
@@ -76,7 +76,7 @@ Name[sr]=Дипин Преузимач
 Name[tr]=Deepin İndirici
 Name[ug]=Deepin چۈشۈرگۈچ
 Name[uk]=Отримувач даних Deepin
-Name[zh_CN]=深度下载器
-Name[zh_HK]=Deepin 下載器
-Name[zh_TW]=Deepin 下載器
+Name[zh_CN]=下载器
+Name[zh_HK]=下載器
+Name[zh_TW]=下載器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese Name/Comment translations in the downloader.desktop file by removing obsolete "深度"/"deepin"/"Deepin" prefixes.