### PR TITLE
chore: Update version to 6.0.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-downloader (6.0.24) unstable; urgency=medium
+
+  * chore: Update version to 6.0.24
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * [skip CI] Translate downloader.ts in it
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:09:19 +0800
+
 deepin-downloader (6.0.23) unstable; urgency=medium
 
   * chore: Update version to 6.0.23


### PR DESCRIPTION
- update version to 6.0.24

log: update version to 6.0.24

## Summary by Sourcery

Chores:
- Increment the recorded version to 6.0.24 in the Debian changelog.