### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file

### DIFF
--- a/desktop/downloader.desktop
+++ b/desktop/downloader.desktop
@@ -9,6 +9,7 @@ Name=Deepin Downloader
 StartupNotify=false
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add `X-Deepin-Singleton=true` to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

为单例应用的 desktop 文件添加 `X-Deepin-Singleton=true` 标识。

Log: 添加单例应用标识
PMS: TASK-392841
Influence: AM 能识别单例应用，Treeland 不再为单例应用显示快速启动画面

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add the X-Deepin-Singleton flag to the downloader desktop entry so it is recognized as a singleton application.