### PR TITLE
fix: update version to 6.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-downloader (6.0.25) unstable; urgency=medium
+
+  * chore: Update version to 6.0.25 
+
+ -- Tian ShiLin <tianshilin@uniontech.com >  Thu, 06 Aug 2026 10:52:57 +0800
+
 deepin-downloader (6.0.24) unstable; urgency=medium
 
   * chore: Update version to 6.0.24


### PR DESCRIPTION
log: update version.

## Summary by Sourcery

Chores:
- Bump Debian packaging metadata to version 6.0.25 in the changelog.