### PR TITLE
fix: restore string-column sorting in download list on Qt6

### DIFF
--- a/src/include/ui/mainFrame/tableModel.h
+++ b/src/include/ui/mainFrame/tableModel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -244,10 +244,6 @@ signals:
      */
     void CheckChange(bool checked, int flag);
 
-    /**
-     * @brief 排序后数据改变
-     */
-    void layoutChanged();
 private slots:
     /**
      * @brief 获取选中改变

--- a/src/src/ui/mainFrame/tableModel.cpp
+++ b/src/src/ui/mainFrame/tableModel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -34,6 +34,7 @@
 #include <QString>
 #include <QStandardItemModel>
 #include <QMimeData>
+#include <QMetaType>
 
 #include "settings.h"
 #include <dpinyin.h>
@@ -713,24 +714,27 @@ int TableModel::DownloadingCount()
 typedef bool (*LessThan)(const QPair<QVariant, int> &left,
                          const QPair<QVariant, int> &right);
 
+// 数值型（文件大小、下载速度，已转为 QVariant(double)）按数值比较；
+// 字符串型（文件名、完成时间、创建时间等，经拼音转换为 QVariant(QString)）按字符串比较。
+// Qt6 弃用了 QVariant 的比较运算符，原实现统一 toDouble() 会使字符串列比较值塌缩为相等，
+// 导致 std::stable_sort 退化为空操作、排序失效，故按存储类型分派比较。
+inline bool variantLessThan(const QVariant &left, const QVariant &right)
+{
+    if (left.userType() == QMetaType::Double && right.userType() == QMetaType::Double)
+        return left.toDouble() < right.toDouble();
+    return left.toString() < right.toString();
+}
+
 bool itemLessThan(const QPair<QVariant, int> &left,
                   const QPair<QVariant, int> &right)
 {
-#if QT_VERSION_MAJOR > 5
-    return left.first.toDouble() < right.first.toDouble();
-#else
-    return left.first < right.first;
-#endif
+    return variantLessThan(left.first, right.first);
 }
 
 bool itemGreaterThan(const QPair<QVariant, int> &left,
                      const QPair<QVariant, int> &right)
 {
-#if QT_VERSION_MAJOR > 5
-    return right.first.toDouble() < left.first.toDouble();
-#else
-    return right.first < left.first;
-#endif
+    return variantLessThan(right.first, left.first);
 }
 
 void TableModel::sort(int column, Qt::SortOrder order)

--- a/src/src/ui/mainFrame/tableView.cpp
+++ b/src/src/ui/mainFrame/tableView.cpp
@@ -129,7 +129,7 @@ void TableView::initConnections()
     connect(m_TableModel, &TableModel::tableviewAllcheckedOrAllunchecked, this, &TableView::isCheckHeader);
     connect(this, &TableView::isCheckHeader, m_HeaderView, &DownloadHeaderView::onHeaderChecked);
     connect(this, &TableView::Hoverchanged, m_Itemdegegate, &ItemDelegate::onHoverchanged);
-    connect(m_TableModel, &TableModel::layoutChanged, this, &TableView::onModellayoutChanged);
+    connect(m_TableModel, &QAbstractItemModel::layoutChanged, this, &TableView::onModellayoutChanged);
     qDebug() << "[TableView] initConnections function ended";
 }
 


### PR DESCRIPTION
## 根因分析

下载器「已下载列表」点击「文件名」「完成时间」表头均无法排序，默认也不按完成时间排序。

**根因（强根因）**：Qt6 适配提交 `b792763 feat: QT6 adaptation` 将 `TableModel` 的排序比较函数 `itemLessThan`/`itemGreaterThan` 统一改为 `toDouble()` 数值比较。但文件名、完成时间、创建时间等列的排序键是 `QVariant(QString)`，`toDouble()` 对非数字串返回 0（日期串至多返回年份前缀），同列内大量行比较值塌缩为相等，`std::stable_sort` 退化为空操作 → 排序完全失效。数值型列（文件大小、下载速度，已转为 `QVariant(double)`）`toDouble()` 正确，故大小/速度可排、名称/时间不可排，与现象一致。Qt5 分支用 `QVariant::operator<` 按存储类型分派，排序正常，故该回归随 Qt6 适配引入。

**关键证据**：
- `src/src/ui/mainFrame/tableModel.cpp:720` / `:729` — Qt6 分支 `return left.first.toDouble() < right.first.toDouble();`，对字符串型 `QVariant` 误用数值比较。
- `tableModel.cpp:760-816` — 大小/速度列先经 `formatFileSize`/`formatSpeed` 转为 `QVariant(double)`（排序正常），文件名/时间/创建时间列直接存 `QVariant(QString)`（排序失效），与"大小可排、名称/时间不可排"的现象一致。
- 版本考古：`git log -S` 确认该 `toDouble()` 比较仅由 `b792763` 引入且此后未再修改；`git tag --contains` 显示 6.0.1~6.0.25 全部包含；HEAD（6.0.25）仍存在。未发现后续修复，6.0.17 与当前 HEAD 均存在。

## 修复方案

按 `QVariant` 存储类型分派比较：抽出单一 `variantLessThan` 助手——`QVariant(double)` 走数值比较（保留大小/速度列现有行为），其余走 `toString()` 字典序比较（恢复文件名/时间/创建时间列排序）；`itemLessThan`/`itemGreaterThan` 复用该助手。`QVariant::userType()` 与 `QMetaType::Double` 自 Qt5.0 起可用，跨 Qt5/Qt6 无需 `#if QT_VERSION_MAJOR` 分支。同一对比较函数亦用于回收站列表，一并修复。

## 改动安全评估

低风险。`itemLessThan`/`itemGreaterThan` 为文件内自由函数，未在任何头文件声明，全仓仅 2 处内部调用（`sortDownload`、`sortRecycle`），签名不变、行为恢复为调用点所期望的"排序真正生效"。本次改动保留 Qt6 适配的编译意图（不依赖 Qt6 已移除的 `QVariant::operator<`），仅修正比较语义，不撤销任何历史修复。`tests/` 下无对这两个比较函数的断言。

## 关联

- PMS: BUG-351519 (https://pms.uniontech.com/bug-view-351519.html)

## Summary by Sourcery

Bug Fixes:
- Fix broken sorting of filename and time-based columns by dispatching QVariant comparisons to numeric or string comparison based on stored type.