### PR TITLE
chore: Update version to 6.0.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-downloader (6.0.26) unstable; urgency=medium
+
+  * chore: Update version to 6.0.26
+  * fix: restore download list sorting and view refresh on Qt6
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 13 Aug 2026 19:15:51 +0800
+
 deepin-downloader (6.0.25) unstable; urgency=medium
 
   * chore: Update version to 6.0.25 


### PR DESCRIPTION
- update version to 6.0.26

log: update version to 6.0.26

## Summary by Sourcery

Chores:
- Refresh Debian changelog entries to reflect release version 6.0.26.