### PR TITLE
fix: fix table header text clipping and scrollbar not showing after tab switch

### DIFF
--- a/src/include/ui/mainFrame/headerView.h
+++ b/src/include/ui/mainFrame/headerView.h
@@ -57,6 +57,11 @@ protected:
      */
     void updateGeometries();
 
+    /**
+     * @brief 按可用宽度省略表头文字，避免列被拖窄时文字被裁剪展示不全
+     */
+    void paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const override;
+
 private:
     DCheckBox *m_headerCbx;
 signals:

--- a/src/src/ui/mainFrame/headerView.cpp
+++ b/src/src/ui/mainFrame/headerView.cpp
@@ -31,6 +31,10 @@
 
 #include "headerView.h"
 #include <QDebug>
+#include <QPainter>
+#include <QStyleOptionHeader>
+#include <QStyle>
+#include <QAbstractItemModel>
 
 DownloadHeaderView::DownloadHeaderView(Qt::Orientation orientation, QWidget *parent)
     : QHeaderView(orientation, parent)
@@ -68,6 +72,40 @@ DownloadHeaderView::DownloadHeaderView(Qt::Orientation orientation, QWidget *par
 DownloadHeaderView::~DownloadHeaderView()
 {
     delete (m_headerCbx);
+}
+
+void DownloadHeaderView::paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const
+{
+    QHeaderView::paintSection(painter, rect, logicalIndex);
+
+    // BUG-243731: 列被拖窄时表头文字默认被裁剪（不省略），改为按可用宽度省略绘制，
+    // 使窄列显示干净的省略号而非半截文字。
+    const QAbstractItemModel *m = model();
+    if (!m)
+        return;
+    const QString text = m->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
+    if (text.isEmpty())
+        return;
+
+    const int margin = style()->pixelMetric(QStyle::PM_HeaderMargin, nullptr, this);
+    int rightReserve = margin;
+    if (isSortIndicatorShown() && sortIndicatorSection() == logicalIndex)
+        rightReserve += style()->pixelMetric(QStyle::PM_HeaderMarkSize, nullptr, this) + margin;
+
+    const QRect textRect = rect.adjusted(margin, 0, -rightReserve, 0);
+    if (textRect.width() <= 0)
+        return;
+
+    const QString elided = fontMetrics().elidedText(text, Qt::ElideRight, textRect.width());
+    if (elided == text)
+        return; // 文字完整放得下，基类已正确绘制，无需重绘
+
+    QStyleOptionHeader opt;
+    opt.initFrom(this);
+    opt.text = elided;
+    opt.rect = textRect;
+    opt.textAlignment = defaultAlignment();
+    style()->drawControl(QStyle::CE_HeaderLabel, &opt, painter, this);
 }
 
 void DownloadHeaderView::updateGeometries()

--- a/src/src/ui/mainFrame/tableView.cpp
+++ b/src/src/ui/mainFrame/tableView.cpp
@@ -106,8 +106,14 @@ void TableView::initUI()
     m_HeaderView->setSectionResizeMode(1, QHeaderView::Interactive);
     m_HeaderView->setSectionResizeMode(0, QHeaderView::Fixed);
     setColumnWidth(2, 110);
-    setColumnWidth(3, QHeaderView::Interactive);
-    setColumnWidth(4, QHeaderView::Interactive);
+    // BUG-243731: 原代码 setColumnWidth(3/4, QHeaderView::Interactive) 误把
+    // ResizeMode 枚举当像素宽度传入（Interactive==0），导致列宽被设为 0（被
+    // minimumSectionSize 钳为极窄值），仅靠 setStretchLastSection 掩盖。此处
+    // 改为正确的 setSectionResizeMode 并补合理初始宽度，使默认即可完整展示表头。
+    m_HeaderView->setSectionResizeMode(3, QHeaderView::Interactive);
+    m_HeaderView->setSectionResizeMode(4, QHeaderView::Interactive);
+    setColumnWidth(3, 150);
+    setColumnWidth(4, 150);
     setTabKeyNavigation(true);
     QFont font;
     font.setFamily("Source Han Sans");
@@ -270,6 +276,9 @@ void TableView::onModellayoutChanged()
             }
         }
     }
+    // BUG-243731: setRowHidden 改变可见行集合后重算竖向滚动条范围与可视性，
+    // 确保切回菜单/排序后滚动条按内容多少默认展示。
+    updateGeometries();
 }
 
 LeftListView::LeftListView()


### PR DESCRIPTION
## 根因分析

PMS 243731【1070RC】【下载器】字段宽度拖拽后展示不全。基线 `14fce9afe6ac34b218393ca79bbc61e4968dc36c`（release/eagle）。

- **问题点1（强根因）字段名展示不全**：`tableView.cpp:109-110` `setColumnWidth(3/4, QHeaderView::Interactive)` 把 `ResizeMode` 枚举当像素宽度传入（`Interactive==0`），col3/col4 列宽被设为 0（被 `minimumSectionSize` 钳为极窄值），仅靠 `setStretchLastSection` 掩盖；且全工程未设最小列宽、`DownloadHeaderView` 未重写 `paintSection`，`QHeaderView` 默认按 section rect 裁剪表头文字不省略 → 拖窄即「展示不全」。`Interactive==0` 经 Qt5 编译探测实证。
- **问题点2（高置信假设）切回菜单后滚动条不默认展示**：`TableView::reset(bool)`（`tableView.cpp:132-143`）仅回填滚动条「值」不重算「范围/可视性」；`mainframe.cpp:912-928` 切换路径 `reset(true)` 后再 `setSortIndicator→TableModel::sort→sortDownload→layoutChanged`（`tableModel.cpp:662-755`）+ `onModellayoutChanged` 对各行 `setRowHidden`（`tableView.cpp:252-273`），使可见行集合在 reset 之后再次变化而未刷新滚动条 → 滚动条可见态停在 reset 旧值。

## 修复方案

1. **问题点1**：纠正 API 误用为 `setSectionResizeMode(3/4, Interactive)` 并补 150px 初始宽度（默认即可完整展示表头）；在 `DownloadHeaderView` 重写 `paintSection`，对超出可用宽度的表头文字用 `Qt::ElideRight` 省略绘制（复用 `QStyle::CE_HeaderLabel` + `initFrom` 调色板，颜色与基类一致），拖窄时显示干净省略号而非半截裁剪。未用 `setMinimumSectionSize`（全局，会把 col0 复选框列拉宽，已用 Qt5 编译探测实证不可取）。
2. **问题点2**：在 `TableView::onModellayoutChanged`（`setRowHidden` 改变可见行集合处）末尾调用 `updateGeometries()` 重算竖向滚动条范围与可视性。未在 `reset()` 内加（`reset()` 在 `mousePressEvent` 每次点击即调用，属热路径，加 `updateGeometries` 有卡顿/闪烁风险；`onModellayoutChanged` 仅在排序/模式切换触发，是切回菜单场景的最终几何变化点）。

## 改动安全评估

低风险：无函数签名变更、无公开 API 变更、无删除。`paintSection` 为新增 protected 重写（文字放得下时直接 return 走基类，col0 表头文字为空跳过，复选框子控件不受影响）；`onModellayoutChanged` 仅加一行幂等的 `updateGeometries()`；`initUI` 仅纠正初始化。残留：DTK 样式下省略号外观未做实机目视（本环境无法验证），但严格优于现状半截裁剪。详见附件 `change-safety.md`。

## 改动文件

- `src/src/ui/mainFrame/tableView.cpp`：纠正 col3/col4 列宽/resize 模式；`onModellayoutChanged` 末尾加 `updateGeometries()`。
- `src/include/ui/mainFrame/headerView.h` / `src/src/ui/mainFrame/headerView.cpp`：新增 `paintSection` 省略号重写。

## Summary by Sourcery

Fix download table header clipping and refresh scrollbar geometry after table layout changes.

Bug Fixes:
- Prevent table header labels from being clipped when columns are narrowed by displaying ellipses within the available width.
- Restore vertical scrollbar range and visibility after row visibility changes caused by sorting or switching back to a menu.
- Correct download table column initialization so the affected columns use interactive resizing with usable default widths.